### PR TITLE
Refactor sensitivity checks to remove race conditions

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,7 +15,7 @@
   const DYNAMIC_ID_MIN_DIGITS = 5;
   const DYNAMIC_ID_MAX_LENGTH = 30;
   const HOVER_DEBOUNCE_MS = 500;
-  const SENSITIVE_ATTRIBUTES = ['id', 'name', 'autocomplete', 'type', 'placeholder', 'aria-label'];
+  const SENSITIVE_ATTRIBUTES = ['id', 'name', 'autocomplete', 'type', 'placeholder', 'aria-label', 'title', 'aria-description', 'aria-placeholder'];
   // Pre-compiled regex for sensitive data detection (case-insensitive)
   // Uses non-alphanumeric lookarounds to handle snake_case and kebab-case (e.g., api_key, card-number)
   const SENSITIVE_REGEX = /(?<![a-zA-Z])(password|card|cvv|cvc|ssn|email|phone|mobile|tax|social|security|api|key|token|secret|auth|otp|pin|credit|cc)(?![a-zA-Z])/i;

--- a/content.js
+++ b/content.js
@@ -18,7 +18,7 @@
   const SENSITIVE_ATTRIBUTES = ['id', 'name', 'autocomplete', 'type', 'placeholder', 'aria-label'];
   // Pre-compiled regex for sensitive data detection (case-insensitive)
   // Uses non-alphanumeric lookarounds to handle snake_case and kebab-case (e.g., api_key, card-number)
-  const SENSITIVE_REGEX = /(?<![a-zA-Z0-9])(password|card|cvv|cvc|ssn|email|phone|mobile|tax|social|security|api|key|token|secret|auth|otp|pin|credit|cc)(?![a-zA-Z0-9])/i;
+  const SENSITIVE_REGEX = /(?<![a-zA-Z])(password|card|cvv|cvc|ssn|email|phone|mobile|tax|social|security|api|key|token|secret|auth|otp|pin|credit|cc)(?![a-zA-Z])/i;
 
   // Pre-compiled regex for dynamic IDs to avoid re-creation on every call
   const dynamicIdPattern = new RegExp(`\\d{${DYNAMIC_ID_MIN_DIGITS},}`);


### PR DESCRIPTION
- Extracted sensitive attributes to `SENSITIVE_ATTRIBUTES` constant.
- Updated `isSensitive` to use the constant.
- Removed `sensitivityObserver` and `lastInputSensitive` caching logic to eliminate race conditions.
- Updated event handlers to use `isSensitive()` directly.